### PR TITLE
Fixes the compile error for Dart 2

### DIFF
--- a/lib/configure_logging_for_browser.dart
+++ b/lib/configure_logging_for_browser.dart
@@ -90,7 +90,7 @@ class ConfigureLoggingForBrowser {
   static void setLogLevelsFromUrl(LoggingService loggingService, {html.Window window}) {
     window = window ?? html.window;
     // ignore: strong_mode_uses_dynamic_as_bottom
-    final _levelNames = new Map.fromIterable(log.Level.LEVELS, key: (log.Level l) => l.name, value: (log.Level l) => l);
+    final _levelNames = new Map<String, log.Level>.fromIterable(log.Level.LEVELS, key: (log.Level l) => l.name, value: (log.Level l) => l);
 
     final applyLogLevel = () {
       final hash = window.location.hash.replaceFirst('#', '');

--- a/lib/configure_logging_for_browser.dart
+++ b/lib/configure_logging_for_browser.dart
@@ -90,7 +90,7 @@ class ConfigureLoggingForBrowser {
   static void setLogLevelsFromUrl(LoggingService loggingService, {html.Window window}) {
     window = window ?? html.window;
     // ignore: strong_mode_uses_dynamic_as_bottom
-    final _levelNames = new Map<String, log.Level>.fromIterable(log.Level.LEVELS, key: (log.Level l) => l.name, value: (log.Level l) => l);
+    final _levelNames = new Map.fromIterable(log.Level.LEVELS, key: (dynamic l) => l.name, value: (dynamic l) => l);
 
     final applyLogLevel = () {
       final hash = window.location.hash.replaceFirst('#', '');

--- a/lib/src/js_console_proxy.dart
+++ b/lib/src/js_console_proxy.dart
@@ -18,22 +18,36 @@ class JsConsoleProxy {
   void _writeToConsole(_LogLevel level, String msg) {
     switch (level) {
       case _LogLevel.Error:
-        if (_doesExist(LoggingServiceOriginalConsoleMethods.error)) {
-          LoggingServiceOriginalConsoleMethods.error(msg);
+        var errorMethod = null;
+        try {
+          errorMethod = LoggingServiceOriginalConsoleMethods.error;
+        } catch (e) {
+        }
+        if (_doesExist(errorMethod)) {
+          errorMethod(msg);
         } else {
           html.window.console.error(msg);
         }
         break;
       case _LogLevel.Info:
-        if (_doesExist(LoggingServiceOriginalConsoleMethods.info)) {
-          LoggingServiceOriginalConsoleMethods.info(msg);
+        var infoMethod = null;
+        try {
+          infoMethod = LoggingServiceOriginalConsoleMethods.info;
+        } catch (e) {
+        }
+        if (_doesExist(infoMethod)) {
+          infoMethod(msg);
         } else {
           html.window.console.info(msg);
         }
         break;
       case _LogLevel.Log:
-        if (_doesExist(LoggingServiceOriginalConsoleMethods.log)) {
-          LoggingServiceOriginalConsoleMethods.log(msg);
+        var logMethod = null;
+        try {
+          logMethod = LoggingServiceOriginalConsoleMethods.log;} catch (e) {
+        }
+        if (_doesExist(logMethod)) {
+          logMethod(msg);
         } else {
           html.window.console.log(msg);
         }


### PR DESCRIPTION
**Edit:** Fixed it to work with Dart2. Please see the comment below. 

However, still not compatible with Dart 2. We now get an infinite loop with AngularDart on caught errors. It was searching for a field .error of undefined. 