### PR TITLE
Fix: unhandled exception during pre-error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.4.3
+- Fix: unhandled exception during pre-error handling
+
 ## 3.4.2
 - Added parameter handlePreStartJsErrors to avoid collection pre start errors.
 

--- a/lib/configure_logging_for_browser.dart
+++ b/lib/configure_logging_for_browser.dart
@@ -32,7 +32,7 @@ class ConfigureLoggingForBrowser {
           loggingService.handleLogRecord(
             new log.LogRecord(
               log.Level.SEVERE,
-              'collectPreStartJsErrors: the error event has incorrect type: ${error.runtimeType}/${error.toString()}',
+              'collectPreStartJsErrors: the error event has incorrect type: ${error.toString()}',
               'jsPreStartUnhandledErrorLogger',
               error,
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging_service
-version: 3.4.2
+version: 3.4.3
 description: The service for advanced work with logging
 authors:
   - Ivan Evsikov <ivan.evsikov@team.wrike.com>


### PR DESCRIPTION
Problem occurs in JS environment.
Exception looks like this: `jsUnhandledErrorLogger: Uncaught TypeError: get$runtimeType is not a function`.
Looks like it is caused by using multiple Dart runtimes:
- error occurs in the 1st Dart runtime
- the 2nd Dart runtime tries to process it...
- ... and fails, because can't find runtimeType getter